### PR TITLE
Fix category scope name matching with relation from Post model

### DIFF
--- a/app/Http/Controllers/ListPostController.php
+++ b/app/Http/Controllers/ListPostController.php
@@ -16,7 +16,7 @@ class ListPostController extends Controller
             ->when(auth()->check(), function ($q) {
                 $q->with(['userVote']);
             })
-            ->category($category)
+            ->fromCategory($category)
             ->scopes($this->getRouteScope($request))
             ->orderBy($orderColumn, $orderDirection)
             ->paginate()

--- a/app/Post.php
+++ b/app/Post.php
@@ -42,7 +42,7 @@ class Post extends Model
         return $this->comments()->orderBy('created_at', 'DESC');
     }
 
-    public function scopeCategory($query, Category $category)
+    public function scopeFromCategory($query, Category $category)
     {
         if ($category->exists) {
            $query->where('category_id', $category->id);


### PR DESCRIPTION
Fix category matching name with relation name in Post model.

Modified scope from `public function scopeCategory(Category $category) {` to `public function scopeFromCategory(Category $category) {`